### PR TITLE
Catch ClientConnectionError in session refresh

### DIFF
--- a/aioaudiobookshelf/client/session_configuration.py
+++ b/aioaudiobookshelf/client/session_configuration.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 
 from aiohttp.client import DEFAULT_TIMEOUT, ClientSession, ClientTimeout
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_exceptions import ClientConnectionError, ClientResponseError
 
 from aioaudiobookshelf.exceptions import (
     RefreshTokenExpiredError,
@@ -78,6 +78,8 @@ class SessionConfiguration:
                     headers=self.headers_refresh_logout,
                     raise_for_status=True,
                 )
+            except ClientConnectionError as err:
+                raise ServiceUnavailableError from err
             except ClientResponseError as err:
                 if err.code == 503:
                     raise ServiceUnavailableError from err


### PR DESCRIPTION
It's been a while - I thought I had the stupid networking problems fixed - but I "caught" the AudioBookshelf provider dumping 88 lines of exception into the logs on shutdown again, and tracked it down to an uncaught ConnectionTimeoutError. Easy enough to fix, once I had the stack trace.


During shutdown, socketio's reconnect attempt triggers _on_connect_error, which calls refresh(). If the server is unreachable, the aiohttp POST throws ConnectionTimeoutError (a ClientConnectionError subclass) that escapes all the way up to the caller. Catch ClientConnectionError and raise ServiceUnavailableError, which _on_connect_error already handles.