### PR TITLE
Make probe-derived AudioFile/AudioTrack fields nullable

### DIFF
--- a/aioaudiobookshelf/schema/audio.py
+++ b/aioaudiobookshelf/schema/audio.py
@@ -31,7 +31,8 @@ class AudioTrack(_BaseModel):
 
     index: int | None
     start_offset: Annotated[float, Alias("startOffset")]
-    duration: float
+    # null when the server could not probe the source file (e.g. unreadable media)
+    duration: float | None
     title: str
     content_url: Annotated[str, Alias("contentUrl")]
     metadata: FileMetadata | None
@@ -56,13 +57,15 @@ class AudioFile(_BaseModel):
     exclude: bool
     error: str | None = None
     format: str
+    # bit_rate / channels / channel_layout are derived from probing the media and
+    # are null when the server could not probe the source file (e.g. unreadable media)
     duration: float | None
-    bit_rate: Annotated[int, Alias("bitRate")]
+    bit_rate: Annotated[int | None, Alias("bitRate")] = None
     language: str | None = None
     codec: str
     time_base: Annotated[str, Alias("timeBase")]
-    channels: int
-    channel_layout: Annotated[str, Alias("channelLayout")]
+    channels: int | None = None
+    channel_layout: Annotated[str | None, Alias("channelLayout")] = None
     embedded_cover_art: Annotated[str | None, Alias("embeddedCoverArt")] = None
     mime_type: Annotated[str | None, Alias("mimeType")] = None
     # if part of a book


### PR DESCRIPTION
## Problem

When a library batch contains a book whose audio files could not be probed by the Audiobookshelf server, the **entire** library sync in Music Assistant fails — not just the affected item.

ABS returns `null` for the probe-derived fields when it cannot read a source file's media (the file is still listed, with a valid `size` and `codec`, and `error` is even `null`). The schema declared these as required:

| Model | Field | Was | ABS sends |
|---|---|---|---|
| `AudioFile` | `bit_rate` | `int` | `null` |
| `AudioFile` | `channels` | `int` | `null` |
| `AudioFile` | `channel_layout` | `str` | `null` |
| `AudioTrack` | `duration` | `float` | `null` |

mashumaro raises `InvalidFieldValue` on the first `null`, and because `ItemsClient.get_library_item_batch_book()` parses the whole response via `LibraryItemsBatchBookResponse.from_json(data)`, **all** items in the batch fail to deserialize. The sync then aborts:

```
Background task Sync Audiobookshelf audiobooks failed: Field "library_items"
of type list[LibraryItemExpandedBook] in LibraryItemsBatchBookResponse has invalid value [...]
```

## Reproduction

Confirmed against `aioaudiobookshelf==0.1.20` (the version pinned by Music Assistant) using a real failing batch of 27 books. Exactly one book ("Words of Radiance", a GraphicAudio dramatized adaptation) had 20 chapter `.mp3` files with `bitRate`/`duration`/`channels`/`channelLayout` all `null`; this aborted deserialization of the whole batch. Sample file dict:

```python
{'index': 29, 'metadata': {'filename': '029 - Chapter 23 - Assassin.mp3', 'size': 9750693, ...},
 'format': 'MP2/3 (MPEG audio layer 2/3)', 'codec': 'mp3', 'error': None,
 'duration': None, 'bitRate': None, 'channels': None, 'channelLayout': None, ...}
```

## Fix

Make the four probe-derived fields `Optional`. After the change, the same batch deserializes cleanly (27/27 items), preserving `None` for the unprobed fields. `ruff check`, `ruff format`, and `mypy` pass; no other code in the library reads these fields.

This is the root cause behind the long-standing reports in music-assistant/support#5332 (where the actual failing item couldn't be identified from truncated logs).

Refs music-assistant/support#5332
