### PR TITLE
add py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ classifiers = [
   "Environment :: Console",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
 ]
 dependencies = [
   "aiohttp",


### PR DESCRIPTION
`pyproject.toml` already declares the marker in package data:

```toml
[tool.setuptools.package-data]
aioaudiobookshelf = ["py.typed"]
```

but `aioaudiobookshelf/py.typed` does not exist, so nothing is shipped. Without it, [PEP 561](https://peps.python.org/pep-0561/) tells type checkers to ignore the package, and the annotations this library already has are invisible to anything that imports it. Consumers see `Any` everywhere, or have to add `ignore_missing_imports` for `aioaudiobookshelf.*`.

The library is already annotated and already checked: `[tool.mypy]` here sets `disallow_untyped_defs`, `disallow_any_generics`, `warn_return_any` and friends. This just lets everyone else benefit from that work.

## What changed

* Added an empty `aioaudiobookshelf/py.typed`.
* Added the `Typing :: Typed` trove classifier, which is how PyPI advertises the same thing.

No code changes.

## Verification

Built a wheel from this branch and checked what it contains:

```
wheel: aioaudiobookshelf-0.1.22-py3-none-any.whl
py.typed shipped:           True
Typing :: Typed classifier: True
```

Then installed it and ran `mypy --strict` against a downstream consumer with the `ignore_missing_imports` override for `aioaudiobookshelf.*` removed, so that your real types were visible for the first time:

```
Success: no issues found in 13 source files
```

Nothing downstream breaks. Type checkers simply start seeing what is already there.

## Why I noticed

I am building a Home Assistant integration on top of this library. Home Assistant's [integration quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/strict-typing/) has a `strict-typing` rule at the Platinum tier which requires the backing library to be PEP 561 compliant. This one file is the only thing left between that integration and Platinum, which is a nice thing to be able to say about a library that is already this carefully typed.
